### PR TITLE
infra for returning ``MockResponse``

### DIFF
--- a/pytest_response/app.py
+++ b/pytest_response/app.py
@@ -8,69 +8,6 @@ from pytest import MonkeyPatch
 from pytest_response.database import ResponseDB
 from pytest_response.logger import log
 
-# class Controller:
-#     """
-#     Internal controller for interceptors.
-#     """
-
-#     def __init__(
-#         self,
-#         capture: Optional[Type[bool]] = False,
-#         response: Optional[Type[bool]] = False,
-#         remote: Optional[Type[bool]] = False,
-#     ):
-#         self.capture = capture
-#         self.response = response
-#         self.remote = remote
-#         self.url = None
-#         self.host = None
-#         self.https = False
-#         self.headers = {}
-#         self.db = None
-
-#     def _setup_database(self, path: Type[str]):
-#         """
-#         Internal method for setting up the database.
-#         """
-#         self.db = database(path)
-
-#     def build_url(
-#         self, host: Type[str], url: Type[str], https: Optional[Type[bool]] = False
-#     ):
-#         """
-#         Internal controller method for building urls.
-#         """
-#         self.url = url
-#         self.host = host
-#         self.https = https
-#         _scheme = "https://" if https else "http://"
-#         _url = "".join([_scheme, host])
-#         self.url = urljoin(_url, url)
-#         if self._validate_url(_url):
-#             return self.url
-#         raise MalformedUrl(f"URL '{_url}' is invalid")
-
-#     def _validate_url(self, value: Type[str]):
-#         """
-#         Internal method for validating a URL.
-#         """
-#         result = urlparse(value)
-#         return all([result.scheme, result.netloc])
-
-#     def insert(self, *args, **kwargs):
-#         """
-#         Wrapper function for `pytest_response.database.db.insert`
-#         """
-#         return self.db.insert(*args, **kwargs)
-
-#     def get(self, *args, **kwargs):
-#         """
-#         Wrapper function for `pytest_response.database.db.get`
-#         """
-#         return self.db.get(*args, **kwargs)
-
-#     pass
-
 
 class Response:
     """
@@ -221,11 +158,11 @@ class Response:
             mock_lib.uninstall()
         log.debug("interceptors unapplied")
 
-    def insert(self, url, response, *args, **kwargs):
+    def insert(self, url, response, headers, *args, **kwargs):
         """
         Wrapper function for `pytest_response.database.db.insert`
         """
-        return self.db.insert(url, response, *args, **kwargs)
+        return self.db.insert(url, response, headers, *args, **kwargs)
 
     def get(self, url, *args, **kwargs):
         """

--- a/pytest_response/app.py
+++ b/pytest_response/app.py
@@ -6,6 +6,7 @@ from pytest import MonkeyPatch
 
 from pytest_response.database import ResponseDB
 from pytest_response.logger import log
+from pytest_response.exceptions import InterceptorNotFound
 
 
 class Response:
@@ -178,29 +179,5 @@ class Response:
             # If interceptor is not available raise/
             raise InterceptorNotFound(f"Requested interceptor `{mock}` is not available; check `available()`")
         return mock
-
-    pass
-
-
-class MalformedUrl(Exception):
-    """
-    Exception raised when a malformed URL is encountered.
-    """
-
-    def __init__(self, reason):
-        self.reason = reason
-        super().__init__(reason)
-
-    pass
-
-
-class InterceptorNotFound(ModuleNotFoundError):
-    """
-    Exception raised when the requested interceptor is not available.
-    """
-
-    def __init__(self, reason):
-        self.reason = reason
-        super().__init__(reason)
 
     pass

--- a/pytest_response/app.py
+++ b/pytest_response/app.py
@@ -12,7 +12,7 @@ from pytest_response.logger import log
 
 class BaseMockResponse:
     def __init__(self, data: bytes, headers: dict = {}) -> None:
-        self.status = self.code = 200
+        self.status = self.status_code = self.code = 200
         self.msg = self.reason = "OK"
         self.headers = headers
         self.will_close = True
@@ -123,7 +123,7 @@ class Response:
 
     @property
     def available(self) -> List[str]:
-        return self.available_mocks
+        return self._available_mocks
 
     def configure(self, remote: bool, capture: bool, response: bool) -> None:
         self.remote = remote
@@ -177,13 +177,10 @@ class Response:
         """
         Deactivates interceptor modules.
         """
-        try:
-            for lib in self._registered_mocks.values():
-                lib.uninstall()
-                log.debug(f"{lib.__name__} unregistered")
-            self._registered_mocks = {}
-        except Exception:
-            raise
+        for lib in self._registered_mocks.values():
+            lib.uninstall()
+            log.debug(f"{lib.__name__} unregistered")
+        self._registered_mocks = {}
 
     def apply(self, mock) -> None:
         """

--- a/pytest_response/app.py
+++ b/pytest_response/app.py
@@ -1,3 +1,4 @@
+import io
 import pathlib
 import importlib.util
 from typing import List
@@ -7,6 +8,50 @@ from pytest import MonkeyPatch
 from pytest_response.database import ResponseDB
 from pytest_response.exceptions import InterceptorNotFound
 from pytest_response.logger import log
+
+
+class BaseMockResponse:
+    def __init__(self, data: bytes, headers: dict = {}) -> None:
+        self.status = self.code = 200
+        self.msg = self.reason = "OK"
+        self.headers = headers
+        self.will_close = True
+        if not isinstance(data, io.BytesIO):
+            data = io.BytesIO(data)
+        self.fp = data
+
+    def getcode(self) -> int:
+        return self.code
+
+    def flush(self):
+        self.fp.flush()
+
+    def info(self) -> dict:
+        return self.headers
+
+    def read(self, *args, **kwargs) -> bytes:
+        """
+        Wrapper for _io.BytesIO.read
+        """
+        return self.fp.read(*args, **kwargs)
+
+    def readline(self, *args, **kwargs) -> bytes:
+        """
+        Wrapper for _io.BytesIO.readline
+        """
+        return self.fp.readline(*args, **kwargs)
+
+    def readinto(self, *args, **kwargs) -> bytes:
+        """
+        Wrapper for _io.BytesIO.readinto
+        """
+        return self.fp.readinto(*args, **kwargs)
+
+    def close(self) -> None:
+        if hasattr(self, "fp"):
+            self.fp.close()
+
+    pass
 
 
 class Response:

--- a/pytest_response/app.py
+++ b/pytest_response/app.py
@@ -1,7 +1,6 @@
 import pathlib
 import importlib.util
 from typing import List
-from functools import lru_cache
 
 from pytest import MonkeyPatch
 

--- a/pytest_response/app.py
+++ b/pytest_response/app.py
@@ -163,6 +163,15 @@ class Response:
         log.info(f"{mock.name} registered")
         return
 
+    def registermany(self, mocks: List[str]) -> None:
+        """
+        Wrapper for `pytest_response.app.register`
+        Registers interceptor modules; applies using `pytest_response.app.applies`
+        """
+        for mock in mocks:
+            self.register(mock)
+        return
+
     def post(self, mock: str) -> None:
         """
         Registers and applies the mock under the same hood.

--- a/pytest_response/app.py
+++ b/pytest_response/app.py
@@ -36,9 +36,21 @@ class Response:
 
         self.config = {"url": None, "host": None, "https": None, "headers": None}
 
+        self.remote = remote
         self.capture = capture
         self.response = response
-        self.remote = remote
+
+    @property
+    def remote(self) -> bool:
+        return self._remote
+
+    @remote.setter
+    def remote(self, value: bool) -> None:
+        if type(value) is not bool:
+            raise TypeError(f"Encountered `{type(value)}` instead of bool.")
+        log.info(f"remote:{value}")
+        self._remote = value
+        return
 
     @property
     def capture(self) -> bool:
@@ -65,20 +77,14 @@ class Response:
         return
 
     @property
-    def remote(self) -> bool:
-        return self._remote
-
-    @remote.setter
-    def remote(self, value: bool) -> None:
-        if type(value) is not bool:
-            raise TypeError(f"Encountered `{type(value)}` instead of bool.")
-        log.info(f"remote:{value}")
-        self._remote = value
-        return
-
-    @property
     def available(self) -> List[str]:
         return self.available_mocks
+
+    def configure(self, remote: bool, capture: bool, response: bool) -> None:
+        self.remote = remote
+        self.capture = capture
+        self.response = response
+        return
 
     def setup_database(self, path: str) -> None:
         self._db_path = path

--- a/pytest_response/app.py
+++ b/pytest_response/app.py
@@ -5,8 +5,8 @@ from typing import List
 from pytest import MonkeyPatch
 
 from pytest_response.database import ResponseDB
-from pytest_response.logger import log
 from pytest_response.exceptions import InterceptorNotFound
+from pytest_response.logger import log
 
 
 class Response:

--- a/pytest_response/app.py
+++ b/pytest_response/app.py
@@ -1,6 +1,9 @@
 import pathlib
 import importlib.util
 from typing import List
+from functools import lru_cache
+
+from pytest import MonkeyPatch
 
 from pytest_response.database import ResponseDB
 from pytest_response.logger import log
@@ -88,9 +91,11 @@ class Response:
         log.info("<------------------------------------------------------------------->")
         self._basepath = pathlib.Path(__file__).parent
         self._db_path = self._basepath.joinpath(database)
+        self.db = None
         self._path_to_mocks = self._basepath.joinpath(path)
         self._available_mocks = list(self._get_available_mocks())
-        self._registered_mocks = []
+        self._registered_mocks = {}
+        self.mpatch = MonkeyPatch()
 
         self.config = {"url": None, "host": None, "https": None, "headers": None}
 
@@ -159,16 +164,25 @@ class Response:
         """
         Registers interceptor modules; applies using `pytest_response.app.applies`
         """
-        mock = self._path_to_mocks.joinpath(mock)
-        if not mock.suffix:
-            mock = mock.with_suffix(".py")
-        if mock not in self._get_available_mocks():
-            raise InterceptorNotFound(f"Requested interceptor `{mock}` is not available; check `available()`")
+        mock = self._sanatize_interceptor(mock)
+        # Load interceptor
         spec = importlib.util.spec_from_file_location(mock.name, str(mock))
         mock_lib = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mock_lib)
-        self._registered_mocks.append(mock_lib)
+
+        # Register for future use.
+        self._registered_mocks[mock.stem] = mock_lib
         log.info(f"{mock.name} registered")
+        return
+
+    def post(self, mock: str) -> None:
+        """
+        Registers and applies the mock under the same hood.
+
+        Internally uses ``Response.register`` followed by ``Response.apply``
+        """
+        self.register(mock)
+        self.apply(mock)
         return
 
     def unregister(self) -> None:
@@ -176,41 +190,58 @@ class Response:
         Deactivates interceptor modules.
         """
         try:
-            for lib in self._registered_mocks:
+            for lib in self._registered_mocks.values():
                 lib.uninstall()
                 log.debug(f"{lib.__name__} unregistered")
-            self._registered_mocks = []
+            self._registered_mocks = {}
         except Exception:
             raise
 
-    def apply(self) -> bool:
+    def apply(self, mock) -> None:
         """
         Activates intercepter modules.
         """
-        for mock_lib in self._registered_mocks:
+        if mock_lib := self._registered_mocks.get(mock):
             mock_lib.install()
-        log.debug("interceptors applied")
         return
 
-    def unapply(self) -> None:
+    def unapply(self, *args, **kwargs) -> None:
+        return self.unapplyall(*args, **kwargs)
+
+    def applyall(self) -> None:
+        for mock_lib in self._registered_mocks.values():
+            mock_lib.install()
+        return
+
+    def unapplyall(self) -> None:
         """
         Un-applies interceptor modules.
         """
-        for mock_lib in self._registered_mocks:
+        for mock_lib in self._registered_mocks.values():
             mock_lib.uninstall()
         log.debug("interceptors unapplied")
 
-    def insert(self, *args, **kwargs):
+    def insert(self, url, response, *args, **kwargs):
         """
         Wrapper function for `pytest_response.database.db.insert`
         """
-        return self.db.insert(*args, **kwargs)
+        return self.db.insert(url, response, *args, **kwargs)
 
-    def get(self, *args, **kwargs):
+    def get(self, url, *args, **kwargs):
         """
         Wrapper function for `pytest_response.database.db.get`
         """
-        return self.db.get(*args, **kwargs)
+        return self.db.get(url, *args, **kwargs)
+
+    def _sanatize_interceptor(self, mock: str) -> pathlib.Path:
+        mock = self._path_to_mocks.joinpath(mock)
+        if not mock.suffix:
+            # If supplied mock-name is missing .py, add it.
+            mock = mock.with_suffix(".py")
+        if mock not in self._get_available_mocks():
+            # If interceptor is not available raise/
+            raise InterceptorNotFound(f"Requested interceptor `{mock}` is not available; check `available()`")
+        return mock
 
     pass
 

--- a/pytest_response/database.py
+++ b/pytest_response/database.py
@@ -2,9 +2,10 @@ import ast
 import zlib
 from base64 import b64decode, b64encode
 from datetime import date
-from collections.abc import MutableMapping
 
 from tinydb import TinyDB, where
+
+# from collections.abc import MutableMapping
 
 
 class ResponseDB:
@@ -73,27 +74,27 @@ class ResponseDB:
     pass
 
 
-class MockHeaders(MutableMapping):
-    def __init__(self, default_headers={""}, *args, **kwargs):
-        self.store = dict()
-        self.update(dict(*args, **kwargs))
+# class MockHeaders(MutableMapping):
+#     def __init__(self, default_headers={""}, *args, **kwargs):
+#         self.store = dict()
+#         self.update(dict(*args, **kwargs))
 
-    def __repr__(self):
-        return str(self.store)
+#     def __repr__(self):
+#         return str(self.store)
 
-    def __getitem__(self, key):
-        return self.store[key]
+#     def __getitem__(self, key):
+#         return self.store[key]
 
-    def __setitem__(self, key, value):
-        self.store[key] = value
+#     def __setitem__(self, key, value):
+#         self.store[key] = value
 
-    def __delitem__(self, key):
-        del self.store[key]
+#     def __delitem__(self, key):
+#         del self.store[key]
 
-    def __iter__(self):
-        return iter(self.store)
+#     def __iter__(self):
+#         return iter(self.store)
 
-    def __len__(self):
-        return len(self.store)
+#     def __len__(self):
+#         return len(self.store)
 
-    pass
+#     pass

--- a/pytest_response/database.py
+++ b/pytest_response/database.py
@@ -62,6 +62,12 @@ class ResponseDB:
         """
         return self._database.all()
 
+    def truncate(self):
+        """
+        Method to purge all records in the database.
+        """
+        return self._database.truncate()
+
     def close(self):
         if hasattr(self, "_database"):
             self._database.close()

--- a/pytest_response/database.py
+++ b/pytest_response/database.py
@@ -50,7 +50,9 @@ class ResponseDB:
         if element := self._database.search(query):
             res = element[0].get("response")
             headers = element[0].get("headers", "[]")
-            return zlib.decompress(b64decode(res.encode("utf-8"))), ast.literal_eval(zlib.decompress(b64decode(headers)).decode("utf-8"))
+            return zlib.decompress(b64decode(res.encode("utf-8"))), ast.literal_eval(
+                zlib.decompress(b64decode(headers)).decode("utf-8")
+            )
         return b"", {}
 
     def all(self):

--- a/pytest_response/exceptions.py
+++ b/pytest_response/exceptions.py
@@ -1,0 +1,38 @@
+class RemoteBlockedError(RuntimeError):
+    """
+    Exception raised when Remote connections are blocked.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(RemoteBlockedError, self).__init__("A test tried to connect to internet.")
+
+
+class ResponseNotFound(RuntimeError):
+    """
+    Exception raised when response is not locally available.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(ResponseNotFound, self).__init__("Response is not available; try capturing first.")
+
+
+class MalformedUrl(Exception):
+    """
+    Exception raised when a malformed URL is encountered.
+    """
+
+    def __init__(self, reason):
+        super().__init__(reason)
+
+    pass
+
+
+class InterceptorNotFound(ModuleNotFoundError):
+    """
+    Exception raised when the requested interceptor is not available.
+    """
+
+    def __init__(self, reason):
+        super().__init__(reason)
+
+    pass

--- a/pytest_response/exceptions.py
+++ b/pytest_response/exceptions.py
@@ -21,7 +21,7 @@ class MalformedUrl(Exception):
     Exception raised when a malformed URL is encountered.
     """
 
-    def __init__(self, reason):
+    def __init__(self, reason="Malformed URL encountered"):
         super().__init__(reason)
 
     pass
@@ -32,7 +32,7 @@ class InterceptorNotFound(ModuleNotFoundError):
     Exception raised when the requested interceptor is not available.
     """
 
-    def __init__(self, reason):
+    def __init__(self, reason="Interceptor not available; check `Response.available`"):
         super().__init__(reason)
 
     pass

--- a/pytest_response/interceptors/requests_quick.py
+++ b/pytest_response/interceptors/requests_quick.py
@@ -4,8 +4,8 @@ import requests
 import urllib3
 
 from pytest_response import response
-from pytest_response.logger import log
 from pytest_response.exceptions import RemoteBlockedError, ResponseNotFound
+from pytest_response.logger import log
 
 
 def requests_wrapper(func):

--- a/pytest_response/interceptors/requests_quick.py
+++ b/pytest_response/interceptors/requests_quick.py
@@ -1,26 +1,11 @@
 from functools import wraps
-from urllib.parse import urljoin
 
 import requests
 import urllib3
 
 from pytest_response import response
 from pytest_response.logger import log
-
-
-class RemoteBlockedError(RuntimeError):
-    def __init__(self, *args, **kwargs):
-        super(RemoteBlockedError, self).__init__("A test tried to connect to internet.")
-
-
-class ResponseNotFound(RuntimeError):
-    def __init__(self, *args, **kwargs):
-        super(ResponseNotFound, self).__init__("Response is not available; try capturing first.")
-
-
-def _build_url(scheme, host, url):
-    _scheme_host = "://".join([scheme, host])
-    return urljoin(_scheme_host, url)
+from pytest_response.exceptions import RemoteBlockedError, ResponseNotFound
 
 
 def requests_wrapper(func):

--- a/pytest_response/interceptors/requests_quick.py
+++ b/pytest_response/interceptors/requests_quick.py
@@ -27,6 +27,7 @@ def requests_wrapper(func):
     @wraps(func)
     def inner_func(url, params=None, **kwargs):
         if not response.remote:
+            log.error(f"RemoteBlockedError remote:{response.remote}")
             raise RemoteBlockedError
         if response.response:
             data, headers = response.get(url=url)

--- a/pytest_response/interceptors/requests_quick.py
+++ b/pytest_response/interceptors/requests_quick.py
@@ -1,7 +1,8 @@
-import urllib3
-from urllib.parse import urljoin
 from functools import wraps
+from urllib.parse import urljoin
+
 import requests
+import urllib3
 
 from pytest_response import response
 from pytest_response.logger import log

--- a/pytest_response/interceptors/requests_quick.py
+++ b/pytest_response/interceptors/requests_quick.py
@@ -4,6 +4,7 @@ import requests
 import urllib3
 
 from pytest_response import response
+from pytest_response.app import BaseMockResponse
 from pytest_response.exceptions import RemoteBlockedError, ResponseNotFound
 from pytest_response.logger import log
 
@@ -30,36 +31,11 @@ def requests_wrapper(func):
     return inner_func
 
 
-class MockResponse:
+class MockResponse(BaseMockResponse):
     def __init__(self, data, headers={}):
-        self.status = self.code = self.status_code = 200
-        self.msg = self.reason = "OK"
-        self.headers = urllib3.response.HTTPHeaderDict(headers)
-        self.will_close = True
+        headers = urllib3.response.HTTPHeaderDict(headers)
         self.content = data
-        self._fp = None
-
-    def read(self, *args, **kwargs):
-        """
-        Wrapper for _io.BytesIO.read
-        """
-        return self._fp.read(*args, **kwargs)
-
-    def readline(self, *args, **kwargs):
-        """
-        Wrapper for _io.BytesIO.readline
-        """
-        return self._fp.readline(*args, **kwargs)
-
-    def readinto(self, *args, **kwargs):
-        """
-        Wrapper for _io.BytesIO.readinto
-        """
-        return self._fp.readinto(*args, **kwargs)
-
-    def close(self):
-        if hasattr(self, "_fp"):
-            self._fp.close()
+        super().__init__(data, headers)
 
     pass
 
@@ -73,7 +49,6 @@ def install_opener():
 
 def uninstall_opener():
     response.mpatch.undo()
-    # response.mpatch.setattr("urllib.request.urlopen", )
 
 
 install = install_opener

--- a/pytest_response/interceptors/urllib.py
+++ b/pytest_response/interceptors/urllib.py
@@ -5,12 +5,13 @@ import urllib.request
 from ssl import SSLSocket, SSLContext
 from socket import SocketIO
 from urllib.parse import urljoin
-from collections.abc import MutableMapping
 
 import _socket
 
 from pytest_response import response
 from pytest_response.logger import log
+from pytest_response.exceptions import RemoteBlockedError, ResponseNotFound
+
 
 EBADF = getattr(errno, "EBADF", 9)
 EAGAIN = getattr(errno, "EAGAIN", 11)
@@ -314,16 +315,6 @@ def install_opener():
 
 def uninstall_opener():
     urllib.request.install_opener(None)
-
-
-class RemoteBlockedError(RuntimeError):
-    def __init__(self, *args, **kwargs):
-        super(RemoteBlockedError, self).__init__("A test tried to connect to internet.")
-
-
-class ResponseNotFound(RuntimeError):
-    def __init__(self, *args, **kwargs):
-        super(ResponseNotFound, self).__init__("Response is not available; try capturing first.")
 
 
 install = install_opener

--- a/pytest_response/interceptors/urllib.py
+++ b/pytest_response/interceptors/urllib.py
@@ -5,6 +5,7 @@ import urllib.request
 from ssl import SSLSocket, SSLContext
 from socket import SocketIO
 from urllib.parse import urljoin
+from collections.abc import MutableMapping
 
 import _socket
 

--- a/pytest_response/interceptors/urllib.py
+++ b/pytest_response/interceptors/urllib.py
@@ -212,6 +212,7 @@ class ResponseHTTPResponse(http.client.HTTPResponse):
             self.will_close = False
             self.fp = self.output
             self.fp.seek(0)
+            return MockResponse(data=self.fp)
 
         super().begin(*args, **kwargs)
 
@@ -310,13 +311,11 @@ class ResponseHTTPSHandler(urllib.request.HTTPSHandler):
 
 
 class MockResponse:
-    def __init__(self, data, headers):
-        self.code = 200
-        self.status = 200
-        self.msg = "OK"
-        self.reason = "OK"
-        self.headers = headers
-        self.fp = io.BytesIO(data)
+    def __init__(self, data):
+        self.status = self.code = 200
+        self.msg = self.reason = "OK"
+        self.headers = MockHeaders()
+        self.fp = data
         self.will_close = True
 
     def flush(self):
@@ -360,6 +359,32 @@ class MockResponse:
         """
         if hasattr(self, "fp"):
             self.fp.close()
+
+    pass
+
+
+class MockHeaders(MutableMapping):
+    def __init__(self, default_headers={""}, *args, **kwargs):
+        self.store = dict()
+        self.update(dict(*args, **kwargs))
+
+    def __repr__(self):
+        return str(self.store)
+
+    def __getitem__(self, key):
+        return self.store[key]
+
+    def __setitem__(self, key, value):
+        self.store[key] = value
+
+    def __delitem__(self, key):
+        del self.store[key]
+
+    def __iter__(self):
+        return iter(self.store)
+
+    def __len__(self):
+        return len(self.store)
 
     pass
 

--- a/pytest_response/interceptors/urllib.py
+++ b/pytest_response/interceptors/urllib.py
@@ -58,7 +58,6 @@ class ResponseSocketIO(SocketIO):
         if response.capture and response.remote:
             global CONFIG
             url = CONFIG.get("url")
-            log.debug(f"dumped {url}")
             response.insert(url=url, response=self.output.getvalue(), headers={})
 
 
@@ -88,7 +87,6 @@ class ResponseSocket(_socket.socket):
             raise RemoteBlockedError
 
         if not response.response:
-            log.debug(f"Connecting...to {self.host}:{self.port} response:{response.response}")
             super().connect((self.host, self.port), *args, **kwargs)
 
     def close(self):
@@ -175,7 +173,6 @@ class Response_SSLSocket(SSLSocket):
         if response.capture and response.remote:
             global CONFIG
             url = CONFIG.get("url")
-            log.debug(f"dumped {url}")
             response.insert(url=url, response=self.output.getvalue(), headers={})
 
     pass
@@ -195,8 +192,6 @@ class ResponseHTTPResponse(http.client.HTTPResponse):
         if not response.remote:
             log.error(f"remote:{response.remote}")
             raise RemoteBlockedError
-
-        log.debug(f"begin response fetching/framing capture:{response.capture} response:{response.response}")
 
         if response.response:
             global CONFIG
@@ -274,7 +269,7 @@ class ResponseHTTPSConnection(http.client.HTTPSConnection, ResponseHTTPConnectio
             log.error(f"Attempting to connect. remote:{response.remote}")
             raise RemoteBlockedError
 
-        log.info("Intercepting call to %s:%s\n" % (self.host, self.port))
+        log.debug("Intercepting call to %s:%s\n" % (self.host, self.port))
         self.sock = ResponseSocket(
             host=self.host,
             port=self.port,
@@ -308,59 +303,6 @@ class ResponseHTTPSHandler(urllib.request.HTTPSHandler):
 
     def https_open(self, req):
         return self.do_open(ResponseHTTPSConnection, req)
-
-
-class MockResponse:
-    def __init__(self, data):
-        self.status = self.code = 200
-        self.msg = self.reason = "OK"
-        self.headers = MockHeaders()
-        self.fp = data
-        self.will_close = True
-
-    def flush(self):
-        self.fp.flush()
-
-    def info(self):
-        return {}
-
-    def read(self, *args, **kwargs):
-        """
-        Wrapper for _io.BytesIO.read
-        """
-        return self.fp.read(*args, **kwargs)
-
-    def readline(self, *args, **kwargs):
-        """
-        Wrapper for _io.BytesIO.readline
-        """
-        return self.fp.readline(*args, **kwargs)
-
-    def readinto(self, *args, **kwargs):
-        """
-        Wrapper for _io.BytesIO.readinto
-        """
-        return self.fp.readinto(*args, **kwargs)
-
-    def __exit__(self):
-        """
-        Method for properly closing resources.
-        """
-        if hasattr(self, "fp"):
-            self.fp.close()
-
-    def close(self):
-        if hasattr(self, "fp"):
-            self.fp.close()
-
-    def __del__(self):
-        """
-        Method for properly closing resources.
-        """
-        if hasattr(self, "fp"):
-            self.fp.close()
-
-    pass
 
 
 def install_opener():

--- a/pytest_response/interceptors/urllib.py
+++ b/pytest_response/interceptors/urllib.py
@@ -203,7 +203,7 @@ class ResponseHTTPResponse(http.client.HTTPResponse):
                 self.will_close = True
                 log.error(f"Response not found {CONFIG.get('url', '')}")
                 raise ResponseNotFound
-            # self.output.write(b"HTTP/1.0 " + status.encode("ISO-8859-1") + b"\n")
+            self.output.write(b"HTTP/1.0 " + "200".encode("ISO-8859-1") + b"\n")
             self.output.write(data)
             self.will_close = False
             self.fp = self.output

--- a/pytest_response/interceptors/urllib.py
+++ b/pytest_response/interceptors/urllib.py
@@ -213,7 +213,6 @@ class ResponseHTTPResponse(http.client.HTTPResponse):
             self.will_close = False
             self.fp = self.output
             self.fp.seek(0)
-            return MockResponse(data=self.fp)
 
         super().begin(*args, **kwargs)
 

--- a/pytest_response/interceptors/urllib.py
+++ b/pytest_response/interceptors/urllib.py
@@ -9,9 +9,8 @@ from urllib.parse import urljoin
 import _socket
 
 from pytest_response import response
-from pytest_response.logger import log
 from pytest_response.exceptions import RemoteBlockedError, ResponseNotFound
-
+from pytest_response.logger import log
 
 EBADF = getattr(errno, "EBADF", 9)
 EAGAIN = getattr(errno, "EAGAIN", 11)

--- a/pytest_response/interceptors/urllib.py
+++ b/pytest_response/interceptors/urllib.py
@@ -59,7 +59,7 @@ class ResponseSocketIO(SocketIO):
             global CONFIG
             url = CONFIG.get("url")
             log.debug(f"dumped {url}")
-            response.insert(url=url, response=self.output.getvalue())
+            response.insert(url=url, response=self.output.getvalue(), headers={})
 
 
 class ResponseSocket(_socket.socket):
@@ -176,7 +176,7 @@ class Response_SSLSocket(SSLSocket):
             global CONFIG
             url = CONFIG.get("url")
             log.debug(f"dumped {url}")
-            response.insert(url=url, response=self.output.getvalue())
+            response.insert(url=url, response=self.output.getvalue(), headers={})
 
     pass
 
@@ -359,32 +359,6 @@ class MockResponse:
         """
         if hasattr(self, "fp"):
             self.fp.close()
-
-    pass
-
-
-class MockHeaders(MutableMapping):
-    def __init__(self, default_headers={""}, *args, **kwargs):
-        self.store = dict()
-        self.update(dict(*args, **kwargs))
-
-    def __repr__(self):
-        return str(self.store)
-
-    def __getitem__(self, key):
-        return self.store[key]
-
-    def __setitem__(self, key, value):
-        self.store[key] = value
-
-    def __delitem__(self, key):
-        del self.store[key]
-
-    def __iter__(self):
-        return iter(self.store)
-
-    def __len__(self):
-        return len(self.store)
 
     pass
 

--- a/pytest_response/interceptors/urllib3.py
+++ b/pytest_response/interceptors/urllib3.py
@@ -9,11 +9,6 @@ from pytest_response.interceptors.urllib import (  # isort:skip
 )
 
 
-class RemoteBlockedError(RuntimeError):
-    def __init__(self, *args, **kwargs):
-        super(RemoteBlockedError, self).__init__("A test tried to use `urllib.request`")
-
-
 class _Response_HTTPU3_Intercepter(ResponseHTTPConnection, HTTPConnection):
     def __init__(self, *args, **kwargs):
         if "strict" in kwargs and sys.version_info > (3, 0):

--- a/pytest_response/interceptors/urllib3_quick.py
+++ b/pytest_response/interceptors/urllib3_quick.py
@@ -1,0 +1,134 @@
+import io
+import http
+import errno
+import urllib3
+from urllib.parse import urljoin
+from functools import wraps
+
+from pytest_response import response
+from pytest_response.logger import log
+
+
+class RemoteBlockedError(RuntimeError):
+    def __init__(self, *args, **kwargs):
+        super(RemoteBlockedError, self).__init__("A test tried to connect to internet.")
+
+
+class ResponseNotFound(RuntimeError):
+    def __init__(self, *args, **kwargs):
+        super(ResponseNotFound, self).__init__("Response is not available; try capturing first.")
+
+
+def _build_url(scheme, host, url):
+    _scheme_host = "://".join([scheme, host])
+    return urljoin(_scheme_host, url)
+
+def urlopen_wrapper(func):
+    @wraps(func)
+    def inner_func(self, method, url, *args, **kwargs):
+        _url = _build_url(self.scheme, self.host, url)
+        if not response.remote:
+            raise RemoteBlockedError
+        if response.response:
+            data, headers = response.get(url=_url)
+            if not data:
+                log.error(f"Response not found url:{_url}")
+                raise ResponseNotFound
+            print(type(headers))
+            log.error(headers)
+            return MockResponse(data, headers)
+        _ = func(self, method, url, *args, **kwargs)
+        if not response.capture:
+            return _
+        print(_.headers)
+        data = _._fp.read()
+        _._fp = io.BytesIO(data)
+        response.insert(url=_url, response=data, headers=dict(_.headers))
+        return _
+
+    return inner_func
+
+
+class MockResponse:
+    def __init__(self, data, headers={}):
+        self.status = self.code = 200
+        self.msg = self.reason = "OK"
+        self.headers = urllib3.response.HTTPHeaderDict(headers)
+        self.will_close = True
+        if not isinstance(data, io.BytesIO):
+            data = io.BytesIO(data)
+        self._fp = data
+        self.will_close = True
+
+    def flush(self):
+        self._fp.flush()
+
+    def info(self):
+        return {}
+
+    def read(self, *args, **kwargs):
+        """
+        Wrapper for _io.BytesIO.read
+        """
+        return self._fp.read(*args, **kwargs)
+
+    def readline(self, *args, **kwargs):
+        """
+        Wrapper for _io.BytesIO.readline
+        """
+        return self._fp.readline(*args, **kwargs)
+
+    def readinto(self, *args, **kwargs):
+        """
+        Wrapper for _io.BytesIO.readinto
+        """
+        return self._fp.readinto(*args, **kwargs)
+
+    def close(self):
+        if hasattr(self, "_fp"):
+            self._fp.close()
+
+    pass
+
+
+# class MockHeaders(MutableMapping):
+#     def __init__(self, default_headers={""}, *args, **kwargs):
+#         self.store = dict()
+#         self.update(dict(*args, **kwargs))
+
+#     def __repr__(self):
+#         return str(self.store)
+
+#     def __getitem__(self, key):
+#         return self.store[key]
+
+#     def __setitem__(self, key, value):
+#         self.store[key] = value
+
+#     def __delitem__(self, key):
+#         del self.store[key]
+
+#     def __iter__(self):
+#         return iter(self.store)
+
+#     def __len__(self):
+#         return len(self.store)
+
+#     pass
+
+
+def install_opener():
+    u3open = urllib3.connectionpool.HTTPConnectionPool.urlopen
+    nurlopen = urlopen_wrapper(u3open)
+    response.mpatch.setattr("urllib3.connectionpool.HTTPConnectionPool.urlopen", nurlopen)
+    log.error("MPATCHED")
+    return
+
+
+def uninstall_opener():
+    response.mpatch.undo()
+    # response.mpatch.setattr("urllib.request.urlopen", )
+
+
+install = install_opener
+uninstall = uninstall_opener

--- a/pytest_response/interceptors/urllib3_quick.py
+++ b/pytest_response/interceptors/urllib3_quick.py
@@ -26,13 +26,10 @@ def urlopen_wrapper(func):
             if not data:
                 log.error(f"Response not found url:{_url}")
                 raise ResponseNotFound
-            print(type(headers))
-            log.error(headers)
             return MockResponse(data, headers)
         _ = func(self, method, url, *args, **kwargs)
         if not response.capture:
             return _
-        print(_.headers)
         data = _._fp.read()
         _._fp = io.BytesIO(data)
         response.insert(url=_url, response=data, headers=dict(_.headers))

--- a/pytest_response/interceptors/urllib3_quick.py
+++ b/pytest_response/interceptors/urllib3_quick.py
@@ -6,16 +6,7 @@ import urllib3
 
 from pytest_response import response
 from pytest_response.logger import log
-
-
-class RemoteBlockedError(RuntimeError):
-    def __init__(self, *args, **kwargs):
-        super(RemoteBlockedError, self).__init__("A test tried to connect to internet.")
-
-
-class ResponseNotFound(RuntimeError):
-    def __init__(self, *args, **kwargs):
-        super(ResponseNotFound, self).__init__("Response is not available; try capturing first.")
+from pytest_response.exceptions import RemoteBlockedError, ResponseNotFound
 
 
 def _build_url(scheme, host, url):

--- a/pytest_response/interceptors/urllib3_quick.py
+++ b/pytest_response/interceptors/urllib3_quick.py
@@ -5,8 +5,8 @@ from urllib.parse import urljoin
 import urllib3
 
 from pytest_response import response
-from pytest_response.logger import log
 from pytest_response.exceptions import RemoteBlockedError, ResponseNotFound
+from pytest_response.logger import log
 
 
 def _build_url(scheme, host, url):

--- a/pytest_response/interceptors/urllib3_quick.py
+++ b/pytest_response/interceptors/urllib3_quick.py
@@ -1,7 +1,8 @@
 import io
-import urllib3
-from urllib.parse import urljoin
 from functools import wraps
+from urllib.parse import urljoin
+
+import urllib3
 
 from pytest_response import response
 from pytest_response.logger import log

--- a/pytest_response/interceptors/urllib3_quick.py
+++ b/pytest_response/interceptors/urllib3_quick.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 import urllib3
 
 from pytest_response import response
+from pytest_response.app import BaseMockResponse
 from pytest_response.exceptions import RemoteBlockedError, ResponseNotFound
 from pytest_response.logger import log
 
@@ -40,72 +41,10 @@ def urlopen_wrapper(func):
     return inner_func
 
 
-class MockResponse:
+class MockResponse(BaseMockResponse):
     def __init__(self, data, headers={}):
-        self.status = self.code = 200
-        self.msg = self.reason = "OK"
-        self.headers = urllib3.response.HTTPHeaderDict(headers)
-        self.will_close = True
-        if not isinstance(data, io.BytesIO):
-            data = io.BytesIO(data)
-        self._fp = data
-        self.will_close = True
-
-    def flush(self):
-        self._fp.flush()
-
-    def info(self):
-        return {}
-
-    def read(self, *args, **kwargs):
-        """
-        Wrapper for _io.BytesIO.read
-        """
-        return self._fp.read(*args, **kwargs)
-
-    def readline(self, *args, **kwargs):
-        """
-        Wrapper for _io.BytesIO.readline
-        """
-        return self._fp.readline(*args, **kwargs)
-
-    def readinto(self, *args, **kwargs):
-        """
-        Wrapper for _io.BytesIO.readinto
-        """
-        return self._fp.readinto(*args, **kwargs)
-
-    def close(self):
-        if hasattr(self, "_fp"):
-            self._fp.close()
-
-    pass
-
-
-# class MockHeaders(MutableMapping):
-#     def __init__(self, default_headers={""}, *args, **kwargs):
-#         self.store = dict()
-#         self.update(dict(*args, **kwargs))
-
-#     def __repr__(self):
-#         return str(self.store)
-
-#     def __getitem__(self, key):
-#         return self.store[key]
-
-#     def __setitem__(self, key, value):
-#         self.store[key] = value
-
-#     def __delitem__(self, key):
-#         del self.store[key]
-
-#     def __iter__(self):
-#         return iter(self.store)
-
-#     def __len__(self):
-#         return len(self.store)
-
-#     pass
+        headers = urllib3.response.HTTPHeaderDict(headers)
+        super().__init__(data, headers)
 
 
 def install_opener():
@@ -118,7 +57,7 @@ def install_opener():
 
 def uninstall_opener():
     response.mpatch.undo()
-    # response.mpatch.setattr("urllib.request.urlopen", )
+    return
 
 
 install = install_opener

--- a/pytest_response/interceptors/urllib_quick.py
+++ b/pytest_response/interceptors/urllib_quick.py
@@ -20,9 +20,13 @@ def urlopen_wrapper(func):
     @wraps(func)
     def inner_func(url, *args, **kwargs):
         if not response.remote:
+            log.error(f"RemoteBlockedError remote:{response.remote}")
             raise RemoteBlockedError
         if response.response:
             data, headers = response.get(url=url)
+            if not data:
+                log.error(f"Response not found url:{url}")
+                raise ResponseNotFound
             return MockResponse(data, headers)
 
         _ = func(url, *args, **kwargs)
@@ -87,7 +91,6 @@ class MockResponse:
 
 
 def install_opener():
-    log.error(":INSTALLED")
     uopen = urllib.request.urlopen
     nurlopen = urlopen_wrapper(uopen)
     response.mpatch.setattr("urllib.request.urlopen", nurlopen)

--- a/pytest_response/interceptors/urllib_quick.py
+++ b/pytest_response/interceptors/urllib_quick.py
@@ -4,16 +4,7 @@ from functools import wraps
 
 from pytest_response import response
 from pytest_response.logger import log
-
-
-class RemoteBlockedError(RuntimeError):
-    def __init__(self, *args, **kwargs):
-        super(RemoteBlockedError, self).__init__("A test tried to connect to internet.")
-
-
-class ResponseNotFound(RuntimeError):
-    def __init__(self, *args, **kwargs):
-        super(ResponseNotFound, self).__init__("Response is not available; try capturing first.")
+from pytest_response.exceptions import RemoteBlockedError, ResponseNotFound
 
 
 def urlopen_wrapper(func):
@@ -75,13 +66,6 @@ class MockResponse:
         Wrapper for _io.BytesIO.readinto
         """
         return self.fp.readinto(*args, **kwargs)
-
-    def __exit__(self):
-        """
-        Method for properly closing resources.
-        """
-        if hasattr(self, "fp"):
-            self.fp.close()
 
     def close(self):
         if hasattr(self, "fp"):

--- a/pytest_response/interceptors/urllib_quick.py
+++ b/pytest_response/interceptors/urllib_quick.py
@@ -3,6 +3,7 @@ import urllib.request
 from functools import wraps
 
 from pytest_response import response
+from pytest_response.app import BaseMockResponse
 from pytest_response.exceptions import RemoteBlockedError, ResponseNotFound
 from pytest_response.logger import log
 
@@ -32,44 +33,9 @@ def urlopen_wrapper(func):
     return inner_func
 
 
-class MockResponse:
+class MockResponse(BaseMockResponse):
     def __init__(self, data, headers={}):
-        self.status = self.code = 200
-        self.msg = self.reason = "OK"
-        self.headers = headers
-        self.will_close = True
-        if not isinstance(data, io.BytesIO):
-            data = io.BytesIO(data)
-        self.fp = data
-        self.will_close = True
-
-    def flush(self):
-        self.fp.flush()
-
-    def info(self):
-        return {}
-
-    def read(self, *args, **kwargs):
-        """
-        Wrapper for _io.BytesIO.read
-        """
-        return self.fp.read(*args, **kwargs)
-
-    def readline(self, *args, **kwargs):
-        """
-        Wrapper for _io.BytesIO.readline
-        """
-        return self.fp.readline(*args, **kwargs)
-
-    def readinto(self, *args, **kwargs):
-        """
-        Wrapper for _io.BytesIO.readinto
-        """
-        return self.fp.readinto(*args, **kwargs)
-
-    def close(self):
-        if hasattr(self, "fp"):
-            self.fp.close()
+        super().__init__(data, headers)
 
     pass
 
@@ -83,7 +49,6 @@ def install_opener():
 
 def uninstall_opener():
     response.mpatch.undo()
-    # response.mpatch.setattr("urllib.request.urlopen", )
 
 
 install = install_opener

--- a/pytest_response/interceptors/urllib_quick.py
+++ b/pytest_response/interceptors/urllib_quick.py
@@ -3,8 +3,8 @@ import urllib.request
 from functools import wraps
 
 from pytest_response import response
-from pytest_response.logger import log
 from pytest_response.exceptions import RemoteBlockedError, ResponseNotFound
+from pytest_response.logger import log
 
 
 def urlopen_wrapper(func):

--- a/pytest_response/interceptors/urllib_quick.py
+++ b/pytest_response/interceptors/urllib_quick.py
@@ -1,0 +1,130 @@
+import io
+import http
+import errno
+import urllib.request
+from functools import wraps
+
+from pytest_response import response
+from pytest_response.logger import log
+
+
+class RemoteBlockedError(RuntimeError):
+    def __init__(self, *args, **kwargs):
+        super(RemoteBlockedError, self).__init__("A test tried to connect to internet.")
+
+
+class ResponseNotFound(RuntimeError):
+    def __init__(self, *args, **kwargs):
+        super(ResponseNotFound, self).__init__("Response is not available; try capturing first.")
+
+
+def urlopen_wrapper(func):
+    @wraps(func)
+    def inner_func(url, *args, **kwargs):
+        if not response.remote:
+            raise RemoteBlockedError
+        if response.response:
+            data, headers = response.get(url=url)
+            return MockResponse(data, headers)
+
+        _ = func(url, *args, **kwargs)
+        if not response.capture:
+            return _
+        data = _.fp.read()
+        _.fp = io.BytesIO(data)
+        response.insert(url=url, response=data)
+        return _
+
+    return inner_func
+
+
+class MockResponse:
+    def __init__(self, data, headers={}):
+        self.status = self.code = 200
+        self.msg = self.reason = "OK"
+        self.headers = headers
+        self.will_close = True
+        if not isinstance(data, io.BytesIO):
+            data = io.BytesIO(data)
+        self.fp = data
+        self.will_close = True
+
+    def flush(self):
+        self.fp.flush()
+
+    def info(self):
+        return {}
+
+    def read(self, *args, **kwargs):
+        """
+        Wrapper for _io.BytesIO.read
+        """
+        return self.fp.read(*args, **kwargs)
+
+    def readline(self, *args, **kwargs):
+        """
+        Wrapper for _io.BytesIO.readline
+        """
+        return self.fp.readline(*args, **kwargs)
+
+    def readinto(self, *args, **kwargs):
+        """
+        Wrapper for _io.BytesIO.readinto
+        """
+        return self.fp.readinto(*args, **kwargs)
+
+    def __exit__(self):
+        """
+        Method for properly closing resources.
+        """
+        if hasattr(self, "fp"):
+            self.fp.close()
+
+    def close(self):
+        if hasattr(self, "fp"):
+            self.fp.close()
+
+    pass
+
+
+# class MockHeaders(MutableMapping):
+#     def __init__(self, default_headers={""}, *args, **kwargs):
+#         self.store = dict()
+#         self.update(dict(*args, **kwargs))
+
+#     def __repr__(self):
+#         return str(self.store)
+
+#     def __getitem__(self, key):
+#         return self.store[key]
+
+#     def __setitem__(self, key, value):
+#         self.store[key] = value
+
+#     def __delitem__(self, key):
+#         del self.store[key]
+
+#     def __iter__(self):
+#         return iter(self.store)
+
+#     def __len__(self):
+#         return len(self.store)
+
+#     pass
+
+
+def install_opener():
+    log.error(":INSTALLED")
+    uopen = urllib.request.urlopen
+    nurlopen = urlopen_wrapper(uopen)
+    response.mpatch.setattr("urllib.request.urlopen", nurlopen)
+    return
+
+
+def uninstall_opener():
+    response.mpatch.undo()
+    # response.mpatch.setattr("urllib.request.urlopen", )
+
+
+install = install_opener
+uninstall = uninstall_opener

--- a/pytest_response/interceptors/urllib_quick.py
+++ b/pytest_response/interceptors/urllib_quick.py
@@ -1,6 +1,4 @@
 import io
-import http
-import errno
 import urllib.request
 from functools import wraps
 
@@ -32,7 +30,8 @@ def urlopen_wrapper(func):
             return _
         data = _.fp.read()
         _.fp = io.BytesIO(data)
-        response.insert(url=url, response=data)
+        headers = _.headers
+        response.insert(url=url, response=data, headers=dict(headers))
         return _
 
     return inner_func
@@ -85,32 +84,6 @@ class MockResponse:
             self.fp.close()
 
     pass
-
-
-# class MockHeaders(MutableMapping):
-#     def __init__(self, default_headers={""}, *args, **kwargs):
-#         self.store = dict()
-#         self.update(dict(*args, **kwargs))
-
-#     def __repr__(self):
-#         return str(self.store)
-
-#     def __getitem__(self, key):
-#         return self.store[key]
-
-#     def __setitem__(self, key, value):
-#         self.store[key] = value
-
-#     def __delitem__(self, key):
-#         del self.store[key]
-
-#     def __iter__(self):
-#         return iter(self.store)
-
-#     def __len__(self):
-#         return len(self.store)
-
-#     pass
 
 
 def install_opener():

--- a/pytest_response/logger.py
+++ b/pytest_response/logger.py
@@ -1,7 +1,7 @@
 import logging
 
 
-class CustomFormatter(logging.Formatter):
+class Formatter(logging.Formatter):
     """Logging Formatter to add colors and count warning / errors"""
 
     grey = "\033[38;1m"
@@ -36,8 +36,8 @@ def _init_log(level="info"):
     ch = logging.StreamHandler()
     ch.setLevel(logging.ERROR)
     # formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-    fh.setFormatter(CustomFormatter())
-    ch.setFormatter(CustomFormatter())
+    fh.setFormatter(Formatter())
+    ch.setFormatter(Formatter())
     log.addHandler(fh)
     log.addHandler(ch)
     return log

--- a/pytest_response/plugin.py
+++ b/pytest_response/plugin.py
@@ -36,7 +36,9 @@ def pytest_configure(config):
         print(f"Remote: {config.option.remote}")
 
     if config.option.remote_capture and config.option.remote_response:
-        assert not config.option.remote_capture and config.option.remote_response  # either capture or mock_remote
+        assert (
+            not config.option.remote_capture and config.option.remote_response
+        )  # either capture or mock_remote
 
     response.setup_database("basedata.json")
     response.register("urllib_quick")

--- a/pytest_response/plugin.py
+++ b/pytest_response/plugin.py
@@ -1,4 +1,5 @@
 import re
+
 from pytest_response import response
 from pytest_response.logger import log
 
@@ -37,6 +38,13 @@ def pytest_addoption(parser):
         default="basedata.json",
         help="Mock connections requests.",
     )
+    parser.addoption(
+        "--remote-blocked",
+        dest="remote_blocked",
+        action="store_false",
+        default=True,
+        help="Mock connections requests.",
+    )
 
 
 def pytest_configure(config):
@@ -44,10 +52,10 @@ def pytest_configure(config):
     Pytest hook for setting up monkeypatch, if ``--intercept-remote`` is ``True``
     """
     if not config.option.remote and config.option.verbose:
-        print(f"Remote: {config.option.remote}")
+        print(f"Remote:{config.option.remote}")
 
     patch = config.option.remote
-    log.debug(patch)
+    print(f"Patch:{patch}")
     if patch:
         if config.option.remote_capture and config.option.remote_response:
             # either remote_capture or remote_response
@@ -59,7 +67,7 @@ def pytest_configure(config):
 
     response.setup_database(config.option.remote_db)
     response.configure(
-        remote=bool(config.option.remote),
+        remote=bool(config.option.remote_blocked),
         capture=bool(config.option.remote_capture),
         response=config.option.remote_response,
     )

--- a/pytest_response/plugin.py
+++ b/pytest_response/plugin.py
@@ -20,8 +20,8 @@ def pytest_addoption(parser):
         help="Capture connections requests.",
     )
     parser.addoption(
-        "--response",
-        dest="response",
+        "--remote-response",
+        dest="remote_response",
         action="store_true",
         default=False,
         help="Mock connections requests.",
@@ -35,18 +35,19 @@ def pytest_configure(config):
     if not config.option.remote and config.option.verbose:
         print(f"Remote: {config.option.remote}")
 
-    if config.option.remote_capture and config.option.response:
-        assert not config.option.remote_capture and config.option.response  # either capture or mock_remote
+    if config.option.remote_capture and config.option.remote_response:
+        assert not config.option.remote_capture and config.option.remote_response  # either capture or mock_remote
+
     response.setup_database("basedata.json")
     response.register("urllib_quick")
     response.register("requests_quick")
 
-    # if config.option.remote_capture:
-    response.capture = config.option.remote_capture
-    # if config.option.response:
-    response.response = config.option.response
-    # if config.option.remote:
-    response.remote = config.option.remote
+    response.configure(
+        remote=config.option.remote,
+        capture=config.option.remote_capture,
+        response=config.option.remote_response,
+    )
+
     response.applyall()
 
 
@@ -62,9 +63,3 @@ def pytest_unconfigure(config):
     """
     response.unapplyall()
     response.unregister()
-    # global mpatch
-    # if config.option.mock_remote:
-    #     response_unpatch(mpatch)
-    # if not config.option.remote:
-    #     remote_unpatch(mpatch)
-    #     remote_dump(config)

--- a/pytest_response/plugin.py
+++ b/pytest_response/plugin.py
@@ -38,7 +38,7 @@ def pytest_configure(config):
     if config.option.remote_capture and config.option.response:
         assert not config.option.remote_capture and config.option.response  # either capture or mock_remote
     response.setup_database("basedata.json")
-    response.register("urllib")
+    response.register("urllib_quick")
     response.register("urllib3")
 
     # if config.option.remote_capture:
@@ -47,20 +47,20 @@ def pytest_configure(config):
     response.response = config.option.response
     # if config.option.remote:
     response.remote = config.option.remote
+    response.applyall()
 
 
-def pytest_runtest_setup(item):
-    response.apply()
+# def pytest_runtest_setup(item):
 
 
-def pytest_runtest_teardown(item):
-    response.unapply()
+# def pytest_runtest_teardown(item):
 
 
 def pytest_unconfigure(config):
     """
     Pytest hook for cleaning up.
     """
+    response.unapplyall()
     response.unregister()
     # global mpatch
     # if config.option.mock_remote:

--- a/pytest_response/plugin.py
+++ b/pytest_response/plugin.py
@@ -39,7 +39,7 @@ def pytest_configure(config):
         assert not config.option.remote_capture and config.option.response  # either capture or mock_remote
     response.setup_database("basedata.json")
     response.register("urllib_quick")
-    response.register("urllib3")
+    response.register("requests_quick")
 
     # if config.option.remote_capture:
     response.capture = config.option.remote_capture

--- a/pytest_response/plugin.py
+++ b/pytest_response/plugin.py
@@ -14,7 +14,7 @@ def pytest_addoption(parser):
         action="store",
         type=str,
         default=None,
-        help="Patches interceptors. (urllib|requests|urllib3)",
+        help="Patches interceptors. --remote=[urllib|urllib3|urllib_quick|urllib3_quick|requests_quick]",
     )
     parser.addoption(
         "--remote-capture",
@@ -28,7 +28,7 @@ def pytest_addoption(parser):
         dest="remote_response",
         action="store_true",
         default=False,
-        help="Mock connections requests.",
+        help="Mocks connection requests.",
     )
     parser.addoption(
         "--remote-db",
@@ -36,14 +36,14 @@ def pytest_addoption(parser):
         action="store",
         type=str,
         default="basedata.json",
-        help="Mock connections requests.",
+        help="Dumps the captured data to this file. --remote-db=[DUMPFILE]",
     )
     parser.addoption(
         "--remote-blocked",
         dest="remote_blocked",
         action="store_false",
         default=True,
-        help="Mock connections requests.",
+        help="Blocks remote connection requests for all interceptors.",
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,8 +11,10 @@ def test_response_obj():
     assert not all([res.capture, res.remote, res.response])
     assert res.available
 
-    res.register("urllib")
+    assert res.register("urllib") is None
     assert list(res.registered().keys()) == ["urllib"]
+    assert res.registermany(["urllib_quick", "requests_quick"]) is None
+    assert list(res.registered().keys()) == ["urllib", "urllib_quick", "requests_quick"]
 
     with pytest.raises(InterceptorNotFound):
         res.register("invalid_interceptor")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,45 @@
+import io
+
+import pytest
+
+from pytest_response.app import BaseMockResponse, Response
+from pytest_response.exceptions import InterceptorNotFound
+
+
+def test_response_obj():
+    res = Response()
+    assert not all([res.capture, res.remote, res.response])
+    assert res.available
+
+    res.register("urllib")
+    assert list(res.registered().keys()) == ["urllib"]
+
+    with pytest.raises(InterceptorNotFound):
+        res.register("invalid_interceptor")
+
+    with pytest.raises(TypeError):
+        res.remote = "Invalid"
+
+    with pytest.raises(TypeError):
+        res.capture = "Invalid"
+
+    with pytest.raises(TypeError):
+        res.response = "Invalid"
+
+    res.post("urllib3")
+    res.unapply()
+
+
+def test_basemockresponse():
+    res = BaseMockResponse(b"Hello", headers={"Mock": True})
+    assert res.code == res.status_code == res.status == res.getcode() == 200
+    assert res.headers
+    assert res.info()
+    assert res.read()
+    res.fp.seek(0)
+    assert res.readline()
+    res.fp.seek(0)
+    buffer = io.BytesIO()
+    res.readinto(buffer.getbuffer())
+    res.flush()
+    res.close()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,20 @@
+from pytest_response.database import ResponseDB
+
+
+def test_response_db(tmp_path):
+    path = tmp_path / "temp_db.json"
+    db = ResponseDB(path)
+
+    url = "testurl"
+    data = b"Hello, this is a test."
+    headers = {"Test": True}
+    assert db.insert(url=url, response=data, headers=headers) is None
+    get_data, get_headers = db.get(url)
+    assert get_data == data
+    assert get_headers == headers
+    noget_data, noget_headers = db.get("invalid_url")
+    assert noget_data == b""
+    assert noget_headers == {}
+    assert db.all()
+    assert db.index()
+    db.close()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -8,13 +8,20 @@ def test_response_db(tmp_path):
     url = "testurl"
     data = b"Hello, this is a test."
     headers = {"Test": True}
+
     assert db.insert(url=url, response=data, headers=headers) is None
     get_data, get_headers = db.get(url)
     assert get_data == data
     assert get_headers == headers
+
+    assert db.all()
+    assert db.index()
+
+    assert db.truncate() is None
+    assert db.all() == []
+
     noget_data, noget_headers = db.get("invalid_url")
     assert noget_data == b""
     assert noget_headers == {}
-    assert db.all()
-    assert db.index()
+
     db.close()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,9 @@
+import pytest
+
+from pytest_response.exceptions import InterceptorNotFound, MalformedUrl, RemoteBlockedError, ResponseNotFound
+
+
+@pytest.mark.parametrize("exec", [RemoteBlockedError, InterceptorNotFound, ResponseNotFound, MalformedUrl])
+def test_exceptions(exec):
+    with pytest.raises(exec):
+        raise exec

--- a/tests/test_urllib.py
+++ b/tests/test_urllib.py
@@ -1,4 +1,4 @@
-def test_remote(testdir):
+def test_remote_block(testdir):
     testdir.makepyfile(
         """
         import urllib.request
@@ -23,11 +23,116 @@ def test_remote(testdir):
     result = testdir.runpytest("-q", "-p", "no:warnings")
     result.assert_outcomes(failed=3)
 
-    result = testdir.runpytest("-q", "--remote", "-p", "no:warnings")
+
+def test_remote_connection(testdir):
+    testdir.makepyfile(
+        """
+        import urllib.request
+        from pytest_response import response
+        def test_urllib_capture():
+            url = "http://www.testingmcafeesites.com/testcat_ac.html"
+            res = urllib.request.urlopen(url)
+            assert res.status == 200
+            assert res.read()
+
+        def test_urllib_capture_ssl():
+            url = "https://www.python.org"
+            res = urllib.request.urlopen(url)
+            assert res.status == 200
+            assert res.read()
+
+        def test_database():
+            assert response.db.index() == ["http://www.testingmcafeesites.com/testcat_ac.html",
+                                           "https://www.python.org"]
+        """
+    )
+    result = testdir.runpytest("-q", "--remote=urllib_quick|requests_quick", "-p", "no:warnings")
     result.assert_outcomes(passed=2, failed=1)
 
-    result = testdir.runpytest("-q", "--remote", "--remote-capture", "-p", "no:warnings")
+
+def test_remote_capresp(testdir):
+    testdir.makepyfile(
+        """
+        import urllib.request
+        from pytest_response import response
+        def test_urllib_capture():
+            url = "http://www.testingmcafeesites.com/testcat_ac.html"
+            res = urllib.request.urlopen(url)
+            assert res.status == 200
+            assert res.read()
+
+        def test_urllib_capture_ssl():
+            url = "https://www.python.org"
+            res = urllib.request.urlopen(url)
+            assert res.status == 200
+            assert res.read()
+
+        def test_database():
+            assert response.db.index() == ["http://www.testingmcafeesites.com/testcat_ac.html",
+                                           "https://www.python.org"]
+        """
+    )
+    result = testdir.runpytest(
+        "-q", "--remote=urllib_quick|requests_quick", "--remote-capture", "-p", "no:warnings"
+    )
     result.assert_outcomes(passed=3)
 
-    result = testdir.runpytest("-q", "--remote", "--remote-response", "-p", "no:warnings")
+    result = testdir.runpytest(
+        "-q", "--remote=urllib_quick|requests_quick", "--remote-response", "-p", "no:warnings"
+    )
+    result.assert_outcomes(passed=3)
+
+
+def test_remote_connection_full(testdir):
+    testdir.makepyfile(
+        """
+        import urllib.request
+        from pytest_response import response
+        def test_urllib_capture():
+            url = "http://www.testingmcafeesites.com/testcat_ac.html"
+            res = urllib.request.urlopen(url)
+            assert res.status == 200
+            assert res.read()
+
+        def test_urllib_capture_ssl():
+            url = "https://www.python.org"
+            res = urllib.request.urlopen(url)
+            assert res.status == 200
+            assert res.read()
+
+        def test_database():
+            assert response.db.index() == ["http://www.testingmcafeesites.com/testcat_ac.html",
+                                           "https://www.python.org"]
+        """
+    )
+    result = testdir.runpytest("-q", "--remote=urllib|urllib3", "-p", "no:warnings")
+    result.assert_outcomes(passed=2, failed=1)
+
+
+def test_remote_capresp_full(testdir):
+    testdir.makepyfile(
+        """
+        import urllib.request
+        from pytest_response import response
+        def test_urllib_capture():
+            url = "http://www.testingmcafeesites.com/testcat_ac.html"
+            res = urllib.request.urlopen(url)
+            assert res.status == 200
+            assert res.read()
+
+        def test_urllib_capture_ssl():
+            url = "https://www.python.org"
+            res = urllib.request.urlopen(url)
+            assert res.status == 200
+            assert res.read()
+
+        def test_database():
+            assert response.db.index() == ["http://www.testingmcafeesites.com/testcat_ac.html",
+                                           "https://www.python.org"]
+        """
+    )
+    result = testdir.runpytest("-q", "--remote=urllib|urllib3", "--remote-capture", "-p", "no:warnings")
+    result.assert_outcomes(passed=3)
+
+    result = testdir.runpytest("-q", "--remote=urllib|urllib3", "--remote-response", "-p", "no:warnings")
     result.assert_outcomes(passed=3)

--- a/tests/test_urllib.py
+++ b/tests/test_urllib.py
@@ -29,5 +29,5 @@ def test_remote(testdir):
     result = testdir.runpytest("-q", "--remote", "--remote-capture", "-p", "no:warnings")
     result.assert_outcomes(passed=3)
 
-    result = testdir.runpytest("-q", "--remote", "--response", "-p", "no:warnings")
+    result = testdir.runpytest("-q", "--remote", "--remote-response", "-p", "no:warnings")
     result.assert_outcomes(passed=3)

--- a/tests/test_urllib.py
+++ b/tests/test_urllib.py
@@ -20,7 +20,7 @@ def test_remote_block(testdir):
                                            "https://www.python.org"]
         """
     )
-    result = testdir.runpytest("-q", "-p", "no:warnings")
+    result = testdir.runpytest("-q", "--remote-blocked", "-p", "no:warnings")
     result.assert_outcomes(failed=3)
 
 

--- a/tests/test_urllib3.py
+++ b/tests/test_urllib3.py
@@ -20,7 +20,7 @@ def test_remote_blocked(testdir):
                                            "https://www.python.org"]
         """
     )
-    result = testdir.runpytest("-q", "-p", "no:warnings")
+    result = testdir.runpytest("-q", "--remote-blocked", "-p", "no:warnings")
     result.assert_outcomes(failed=3)
 
 

--- a/tests/test_urllib3.py
+++ b/tests/test_urllib3.py
@@ -29,5 +29,5 @@ def test_remote(testdir):
     result = testdir.runpytest("-q", "--remote", "--remote-capture", "-p", "no:warnings")
     result.assert_outcomes(passed=3)
 
-    result = testdir.runpytest("-q", "--remote", "--response", "-p", "no:warnings")
+    result = testdir.runpytest("-q", "--remote", "--remote-response", "-p", "no:warnings")
     result.assert_outcomes(passed=3)

--- a/tests/test_urllib3.py
+++ b/tests/test_urllib3.py
@@ -17,7 +17,7 @@ def test_remote(testdir):
 
         def test_database():
             assert response.db.index() == ["http://www.testingmcafeesites.com/testcat_ac.html",
-                                           "https://www.python.org/"]
+                                           "https://www.python.org"]
         """
     )
     result = testdir.runpytest("-q", "-p", "no:warnings")

--- a/tests/test_urllib3.py
+++ b/tests/test_urllib3.py
@@ -1,4 +1,4 @@
-def test_remote(testdir):
+def test_remote_blocked(testdir):
     testdir.makepyfile(
         """
         import requests
@@ -23,11 +23,120 @@ def test_remote(testdir):
     result = testdir.runpytest("-q", "-p", "no:warnings")
     result.assert_outcomes(failed=3)
 
-    result = testdir.runpytest("-q", "--remote", "-p", "no:warnings")
+
+def test_remote_connection(testdir):
+    testdir.makepyfile(
+        """
+        import requests
+        from pytest_response import response
+        def test_urllib3():
+            url = "http://www.testingmcafeesites.com/testcat_ac.html"
+            res = requests.get(url)
+            assert res.status_code == 200
+            assert res.content
+
+        def test_urllib3_ssl():
+            url = "https://www.python.org"
+            res = requests.get(url)
+            assert res.status_code == 200
+            assert res.content
+
+        def test_database():
+            assert response.db.index() == ["http://www.testingmcafeesites.com/testcat_ac.html",
+                                           "https://www.python.org"]
+        """
+    )
+
+    result = testdir.runpytest("-q", "--remote=urllib_quick|requests_quick", "-p", "no:warnings")
     result.assert_outcomes(passed=2, failed=1)
 
-    result = testdir.runpytest("-q", "--remote", "--remote-capture", "-p", "no:warnings")
+
+def test_remote_capresp(testdir):
+    testdir.makepyfile(
+        """
+        import requests
+        from pytest_response import response
+        def test_urllib3():
+            url = "http://www.testingmcafeesites.com/testcat_ac.html"
+            res = requests.get(url)
+            assert res.status_code == 200
+            assert res.content
+
+        def test_urllib3_ssl():
+            url = "https://www.python.org"
+            res = requests.get(url)
+            assert res.status_code == 200
+            assert res.content
+
+        def test_database():
+            assert response.db.index() == ["http://www.testingmcafeesites.com/testcat_ac.html",
+                                           "https://www.python.org"]
+        """
+    )
+
+    result = testdir.runpytest(
+        "-q", "--remote=urllib_quick|requests_quick", "--remote-capture", "-p", "no:warnings"
+    )
     result.assert_outcomes(passed=3)
 
-    result = testdir.runpytest("-q", "--remote", "--remote-response", "-p", "no:warnings")
+    result = testdir.runpytest(
+        "-q", "--remote=urllib_quick|requests_quick", "--remote-response", "-p", "no:warnings"
+    )
+    result.assert_outcomes(passed=3)
+
+
+def test_remote_connection_full(testdir):
+    testdir.makepyfile(
+        """
+        import requests
+        from pytest_response import response
+        def test_urllib3():
+            url = "http://www.testingmcafeesites.com/testcat_ac.html"
+            res = requests.get(url)
+            assert res.status_code == 200
+            assert res.content
+
+        def test_urllib3_ssl():
+            url = "https://www.python.org"
+            res = requests.get(url)
+            assert res.status_code == 200
+            assert res.content
+
+        def test_database():
+            assert response.db.index() == ["http://www.testingmcafeesites.com/testcat_ac.html",
+                                           "https://www.python.org"]
+        """
+    )
+
+    result = testdir.runpytest("-q", "--remote=urllib|urllib3", "-p", "no:warnings")
+    result.assert_outcomes(passed=2, failed=1)
+
+
+def test_remote_capresp_full(testdir):
+    testdir.makepyfile(
+        """
+        import requests
+        from pytest_response import response
+        def test_urllib3():
+            url = "http://www.testingmcafeesites.com/testcat_ac.html"
+            res = requests.get(url)
+            assert res.status_code == 200
+            assert res.content
+
+        def test_urllib3_ssl():
+            url = "https://www.python.org"
+            res = requests.get(url)
+            assert res.status_code == 200
+            assert res.content
+
+        def test_database():
+            assert response.db.index() == ["http://www.testingmcafeesites.com/testcat_ac.html",
+                                           "https://www.python.org/"]
+        """
+    )
+
+    result = testdir.runpytest("-q", "--remote=urllib|urllib3", "--remote-capture", "-p", "no:warnings")
+    result.assert_outcomes(passed=3)
+
+    result = testdir.runpytest("-q", "--remote=urllib|urllib3", "--remote-response", "-p", "no:warnings")
     result.assert_outcomes(passed=3)


### PR DESCRIPTION
Instead of moving through the whole pipeline of ``urllib``, I feel like it'll be much better to return a Response directly.

This PR works towards making this happen.

Essentially:
- Adds five interceptors, namely:
    - urllib
    - urllib_quick
    - urllib3
    - urllib3_quick
    - requests_quick
- These interceptors can be individually called using `--remote=[urllib|urlib_quick|requests_quick]`

- Connection can be blocked using `--remote-blocked` flag.

- Requests can be captured using ``--remote-capture`` 

- Requests can be mocked using ``--remote-response``

- Improved coverage across the package.

Limitations:
- This PR adds a lot of cmdline args which are probably a bit too much; I'll fix it by using setup.cfg in a future pr.

Future:
- A way to selectively mock or capture libs would be nice to have.